### PR TITLE
Make parameter regex to be configurable.

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -98,7 +98,7 @@
           }
           return _results;
         })();
-        retpat = pat.replace(re, "/([A-Za-z0-9_\-]+)");
+        retpat = pat.replace(re, dispatch.regex);
       } else {
         retpat = pat;
         pars = null;
@@ -229,6 +229,7 @@
       php_cgi: "php-cgi",
       served_by: 'Node Simple Router',
       software_name: 'node-simple-router',
+      regex: "/([A-Za-z0-9_\-]+)",
       admin_user: 'admin',
       admin_pwd: 'admin',
       use_nsr_session: true,


### PR DESCRIPTION
I want to be able to have `/fakePath/:filename` match `/fakePath/file.txt`, but the default regex won't match a `.` in a path.

This Pull Request allows a user to override it like so:

``` javascript
var router = Router({
    regex: "/([A-Za-z0-9_\.\-]+)",
});
```
